### PR TITLE
Add tests asserting that newlines must appear after table names

### DIFF
--- a/assets/invalid/key-after-array.toml
+++ b/assets/invalid/key-after-array.toml
@@ -1,0 +1,1 @@
+[[agencies]] owner = "S Cjelli"

--- a/assets/invalid/key-after-table.toml
+++ b/assets/invalid/key-after-table.toml
@@ -1,0 +1,1 @@
+[history] guard = "sleeping"


### PR DESCRIPTION
Newlines need to appear after table names in TOML. This library rejects TOML where this is not the case, as expected, but I could not find any tests ensuring this (apologies if I'm mistaken!) so I added some :)